### PR TITLE
5.7K 10fps support

### DIFF
--- a/X-specific/low_fps_video/README.md
+++ b/X-specific/low_fps_video/README.md
@@ -2,8 +2,8 @@
 
 THETA X supports the following low FPS video formats with a max video of 2 hours:
 
-* 8K 2fps, 5fps
-* 5.7K 2fps 5fps
+* 8K 2fps, 5fps, 10fps
+* 5.7K 2fps 5fps, 10fps
 
 ## 5.7K video format
 

--- a/X-specific/low_fps_video/fileFormat.5_7k_10_fps.js
+++ b/X-specific/low_fps_video/fileFormat.5_7k_10_fps.js
@@ -1,0 +1,17 @@
+const body = {'name': 'camera.setOptions',
+              "parameters": {
+                "options": {
+                    "fileFormat": {"type": "mp4","width": 5760,"height": 2880, "_codec": "H.264/MPEG-4 AVC", "_frameRate": 10}
+        }   
+    }
+}
+
+const response = await fetch('http://192.168.1.1/osc/commands/execute', 
+	{method: 'POST', 
+	body: JSON.stringify(body),
+	headers: {'Content-Type': 'application/json'}
+});
+
+const data =  await response.json();
+
+console.log(data);


### PR DESCRIPTION
docs on github omit 5.7K 10fps support.  However, it appears to work in my tests.  The omission is likely an oversight.  I updated the fps information in the readme to indicate that 10fps is supported as well as adding a test script for the 5.7K 10fps.